### PR TITLE
Allow delegates to sign transactions

### DIFF
--- a/safe_cli/safe_operator.py
+++ b/safe_cli/safe_operator.py
@@ -593,11 +593,11 @@ class SafeOperator:
 
     # TODO Set sender so we can save gas in that signature
     def sign_transaction(self, safe_tx: SafeTx) -> NoReturn:
-        owners = self.safe_cli_info.owners
+        permitted_signers = self.get_permitted_signers()
         threshold = self.safe_cli_info.threshold
         selected_accounts: List[Account] = []  # Some accounts that are not an owner can be loaded
         for account in self.accounts:
-            if account.address in owners:
+            if account.address in permitted_signers:
                 selected_accounts.append(account)
                 threshold -= 1
                 if threshold == 0:
@@ -616,6 +616,9 @@ class SafeOperator:
             signatures += selected_account.signHash(safe_tx_hash)
         return signatures
         """
+
+    def get_permitted_signers(self) -> Set[str]:
+        return set(self.safe_cli_info.owners)
 
     def process_command(self, first_command: str, rest_command: List[str]) -> bool:
         if first_command == 'help':

--- a/safe_cli/safe_tx_service_operator.py
+++ b/safe_cli/safe_tx_service_operator.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Set
 
 from hexbytes import HexBytes
 from prompt_toolkit import HTML, print_formatted_text
@@ -73,3 +73,10 @@ class SafeTxServiceOperator(SafeOperator):
                                       f'to Gnosis Safe Transaction service</ansigreen>'))
             return True
         return False
+
+    def get_permitted_signers(self) -> Set[str]:
+        owners = super().get_permitted_signers()
+        owners.update(
+            [row['delegate'] for row in self.safe_tx_service.get_delegates(self.address)]
+        )
+        return owners


### PR DESCRIPTION
The CLI would only sign transactions using loaded accounts that are owners of the safe. This change updates the CLI to also sign from any loaded accounts that are registered delegates for the safe