### PR TITLE
Fix duplicated LedgerAccounts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 art==6.1
 colorama==0.4.6
-ledgereth==0.9.0
+ledgereth==0.9.1
 packaging>=23.1
 prompt_toolkit==3.0.40
 pygments==2.16.1

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
         "safe-eth-py==6.0.0b5",
         "tabulate>=0.8",
     ],
-    extras_require={"ledger": ["ledgereth==0.9.0"]},
+    extras_require={"ledger": ["ledgereth==0.9.1"]},
     packages=setuptools.find_packages(),
     entry_points={
         "console_scripts": [

--- a/tests/test_ledger_manager.py
+++ b/tests/test_ledger_manager.py
@@ -153,6 +153,10 @@ class TestLedgerManager(SafeTestCaseMixin, unittest.TestCase):
         ledger_account = list(ledger_manager.accounts)[0]
         self.assertEqual(ledger_account.address, account_address)
         self.assertEqual(ledger_account.path, derivation_path)
+        # Shouldn't duplicate accounts
+        self.assertEqual(ledger_manager.add_account(derivation_path), account_address)
+        self.assertEqual(len(ledger_manager.accounts), 1)
+
         # Should accept derivation paths starting with master
         master_derivation_path = "m/44'/60'/0'/0"
         self.assertEqual(


### PR DESCRIPTION
- Bump ledgereth to [0.9.1](https://github.com/mikeshultz/ledger-eth-lib/releases/tag/v0.9.1)
- Add test to ensure that LedgerAccounts are not duplicated in the the set of accounts.   

Closes #302 
