### PR TITLE
Fix threshold retrieve in tx-service mode

### DIFF
--- a/src/safe_cli/operators/safe_operator.py
+++ b/src/safe_cli/operators/safe_operator.py
@@ -497,7 +497,7 @@ class SafeOperator:
             ).build_transaction({"from": self.address, "gas": 0, "gasPrice": 0})
             if self.execute_safe_internal_transaction(transaction["data"]):
                 self.safe_cli_info.owners = self.safe.retrieve_owners()
-                self.safe_cli_info.threshold = threshold
+                self.safe_cli_info.threshold = self.safe.retrieve_threshold()
                 return True
             return False
 
@@ -519,7 +519,7 @@ class SafeOperator:
             ).build_transaction({"from": self.address, "gas": 0, "gasPrice": 0})
             if self.execute_safe_internal_transaction(transaction["data"]):
                 self.safe_cli_info.owners = self.safe.retrieve_owners()
-                self.safe_cli_info.threshold = threshold
+                self.safe_cli_info.threshold = self.safe.retrieve_threshold()
                 return True
             return False
 
@@ -760,7 +760,7 @@ class SafeOperator:
             ).build_transaction({"from": self.address, "gas": 0, "gasPrice": 0})
 
             if self.execute_safe_internal_transaction(transaction["data"]):
-                self.safe_cli_info.threshold = threshold
+                self.safe_cli_info.threshold = self.safe.retrieve_threshold()
 
     def enable_module(self, module_address: str):
         if module_address in self.safe_cli_info.modules:

--- a/src/safe_cli/operators/safe_tx_service_operator.py
+++ b/src/safe_cli/operators/safe_tx_service_operator.py
@@ -271,7 +271,10 @@ class SafeTxServiceOperator(SafeOperator):
                 )
             )
         else:
-            return self.execute_safe_transaction(safe_tx)
+            executed = self.execute_safe_transaction(safe_tx)
+            if executed:
+                self.refresh_safe_cli_info()
+            return executed
 
     def get_balances(self):
         balances = self.safe_tx_service.get_balances(self.address)

--- a/src/safe_cli/operators/safe_tx_service_operator.py
+++ b/src/safe_cli/operators/safe_tx_service_operator.py
@@ -271,8 +271,7 @@ class SafeTxServiceOperator(SafeOperator):
                 )
             )
         else:
-            executed = self.execute_safe_transaction(safe_tx)
-            if executed:
+            if executed := self.execute_safe_transaction(safe_tx):
                 self.refresh_safe_cli_info()
             return executed
 


### PR DESCRIPTION
# Description 
When the safe-cli is running on ts-service mode the threshold was wrongly updated to the new value during a `change_threshold` command call. 
The issue was that the function `prepare_and_execute_transaction` is overwritten by the `SafeTxOperator` class with the difference that instead execute the transaction in blockchain, the overwritten function POST the transaction to the Safe Transaction Service without execute it.

# Proposal solution
Update from blockchain the threshold value. 


# Related issue
Closes #323 
 