### PR TITLE
Add hw wallet sign message

### DIFF
--- a/src/safe_cli/operators/hw_wallets/hw_wallet.py
+++ b/src/safe_cli/operators/hw_wallets/hw_wallet.py
@@ -58,6 +58,15 @@ class HwWallet(ABC):
         :return: raw transaction signed
         """
 
+    @abstractmethod
+    def sign_message(self, message: bytes) -> bytes:
+        """
+        Call sign message of hw wallet
+
+        :param message:
+        :return: bytes signature
+        """
+
     def __str__(self):
         return f"{self.__class__.__name__} device with address {self.address}"
 

--- a/src/safe_cli/operators/hw_wallets/hw_wallet_manager.py
+++ b/src/safe_cli/operators/hw_wallets/hw_wallet_manager.py
@@ -222,6 +222,7 @@ class HwWalletManager:
         self, message: bytes, wallets: List[HwWallet]
     ) -> List[SafeSignature]:
         """
+        Sign a message for all the provided wallets
 
         :param message:
         :param wallets:

--- a/src/safe_cli/operators/hw_wallets/hw_wallet_manager.py
+++ b/src/safe_cli/operators/hw_wallets/hw_wallet_manager.py
@@ -10,7 +10,11 @@ from web3.types import TxParams, Wei
 from gnosis.eth import TxSpeed
 from gnosis.eth.eip712 import eip712_encode, eip712_encode_hash
 from gnosis.safe import SafeTx
-from gnosis.safe.safe_signature import SafeSignature, SafeSignatureEOA
+from gnosis.safe.safe_signature import (
+    SafeSignature,
+    SafeSignatureEOA,
+    SafeSignatureEthSign,
+)
 
 from .hw_wallet import HwWallet
 
@@ -213,3 +217,25 @@ class HwWalletManager:
         # so signatures are not valid anymore
         safe_tx.signatures = b""
         return safe_tx.tx_hash, safe_tx.tx
+
+    def sign_message(
+        self, message: bytes, wallets: List[HwWallet]
+    ) -> List[SafeSignature]:
+        """
+
+        :param message:
+        :param wallets:
+        :return:
+        """
+        signatures: List[SafeSignature] = []
+        for wallet in wallets:
+            print_formatted_text(
+                HTML(
+                    f"<ansired>Make sure before signing in your {wallet} that the message is correct</ansired>"
+                )
+            )
+            signatures.append(
+                SafeSignatureEthSign(wallet.sign_message(message), message)
+            )
+
+        return signatures

--- a/src/safe_cli/operators/hw_wallets/ledger_wallet.py
+++ b/src/safe_cli/operators/hw_wallets/ledger_wallet.py
@@ -3,7 +3,7 @@ from typing import Optional
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
 from ledgerblue.Dongle import Dongle
-from ledgereth import create_transaction, sign_typed_data_draft
+from ledgereth import create_transaction, sign_message, sign_typed_data_draft
 from ledgereth.accounts import get_account_by_path
 from ledgereth.comms import init_dongle
 from web3.types import TxParams
@@ -75,3 +75,9 @@ class LedgerWallet(HwWallet):
             dongle=self.dongle,
         )
         return HexBytes(signed_transaction.raw_transaction())
+
+    @raise_ledger_exception_as_hw_wallet_exception
+    def sign_message(self, message: bytes) -> bytes:
+        signed = sign_message(message, self.derivation_path, self.dongle)
+        # V field must be greater than 30 for signed messages. https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L309
+        return signature_to_bytes(signed.v + 4, signed.r, signed.s)

--- a/src/safe_cli/operators/hw_wallets/ledger_wallet.py
+++ b/src/safe_cli/operators/hw_wallets/ledger_wallet.py
@@ -78,6 +78,12 @@ class LedgerWallet(HwWallet):
 
     @raise_ledger_exception_as_hw_wallet_exception
     def sign_message(self, message: bytes) -> bytes:
+        """
+        Call sign message of Ledger wallet
+
+        :param message:
+        :return: bytes signature
+        """
         signed = sign_message(message, self.derivation_path, self.dongle)
         # V field must be greater than 30 for signed messages. https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L309
         return signature_to_bytes(signed.v + 4, signed.r, signed.s)

--- a/src/safe_cli/operators/hw_wallets/trezor_wallet.py
+++ b/src/safe_cli/operators/hw_wallets/trezor_wallet.py
@@ -139,6 +139,12 @@ class TrezorWallet(HwWallet):
 
     @raise_trezor_exception_as_hw_wallet_exception
     def sign_message(self, message: bytes) -> bytes:
+        """
+        Call sign message of Trezor wallet
+
+        :param message:
+        :return: bytes signature
+        """
         signed = sign_message(self.client, self.address_n, message)
         # V field must be greater than 30 for signed messages. https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L309
         v, r, s = signature_split(signed.signature)

--- a/src/safe_cli/operators/hw_wallets/trezor_wallet.py
+++ b/src/safe_cli/operators/hw_wallets/trezor_wallet.py
@@ -7,12 +7,15 @@ from trezorlib import tools
 from trezorlib.client import TrezorClient, get_default_client
 from trezorlib.ethereum import (
     get_address,
+    sign_message,
     sign_tx,
     sign_tx_eip1559,
     sign_typed_data_hash,
 )
 from trezorlib.ui import ClickUI
 from web3.types import TxParams
+
+from gnosis.safe.signatures import signature_split, signature_to_bytes
 
 from .hw_wallet import HwWallet
 from .trezor_exceptions import raise_trezor_exception_as_hw_wallet_exception
@@ -34,6 +37,7 @@ def get_trezor_client() -> TrezorClient:
 class TrezorWallet(HwWallet):
     def __init__(self, derivation_path: str):
         self.client: TrezorClient = get_trezor_client()
+        self.address_n = tools.parse_path(derivation_path)
         super().__init__(derivation_path)
 
     @raise_trezor_exception_as_hw_wallet_exception
@@ -41,8 +45,7 @@ class TrezorWallet(HwWallet):
         """
         :return: public address for derivation_path
         """
-        address_n = tools.parse_path(self.derivation_path)
-        return get_address(client=self.client, n=address_n)
+        return get_address(client=self.client, n=self.address_n)
 
     @raise_trezor_exception_as_hw_wallet_exception
     def sign_typed_hash(self, domain_hash: bytes, message_hash: bytes) -> bytes:
@@ -52,9 +55,11 @@ class TrezorWallet(HwWallet):
         :param message_hash:
         :return: signature bytes
         """
-        address_n = tools.parse_path(self.derivation_path)
         signed = sign_typed_data_hash(
-            self.client, n=address_n, domain_hash=domain_hash, message_hash=message_hash
+            self.client,
+            n=self.address_n,
+            domain_hash=domain_hash,
+            message_hash=message_hash,
         )
         return signed.signature
 
@@ -68,12 +73,11 @@ class TrezorWallet(HwWallet):
         :param tx_parameters:
         :return: raw transaction signed
         """
-        address_n = tools.parse_path(self.derivation_path)
         if tx_parameters.get("maxPriorityFeePerGas"):
             # EIP1559
             v, r, s = sign_tx_eip1559(
                 self.client,
-                n=address_n,
+                n=self.address_n,
                 nonce=tx_parameters["nonce"],
                 gas_limit=tx_parameters["gas"],
                 to=tx_parameters["to"],
@@ -107,7 +111,7 @@ class TrezorWallet(HwWallet):
             # Legacy transaction
             v, r, s = sign_tx(
                 self.client,
-                n=address_n,
+                n=self.address_n,
                 nonce=tx_parameters["nonce"],
                 gas_price=tx_parameters["gasPrice"],
                 gas_limit=tx_parameters["gas"],
@@ -132,3 +136,10 @@ class TrezorWallet(HwWallet):
             ).hex()
 
         return HexBytes(encoded_transaction)
+
+    @raise_trezor_exception_as_hw_wallet_exception
+    def sign_message(self, message: bytes) -> bytes:
+        signed = sign_message(self.client, self.address_n, message)
+        # V field must be greater than 30 for signed messages. https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L309
+        v, r, s = signature_split(signed.signature)
+        return signature_to_bytes(v + 4, r, s)

--- a/src/safe_cli/operators/safe_operator.py
+++ b/src/safe_cli/operators/safe_operator.py
@@ -1065,6 +1065,7 @@ class SafeOperator:
 
     def get_signers(self) -> Tuple[List[LocalAccount], List[HwWallet]]:
         """
+        Get the signers necessary to sign a transaction, raise an exception if was not uploaded enough signers.
 
         :return: Tuple with eoa signers and hw_wallet signers
         """


### PR DESCRIPTION
# Description
Add support to sign messages using hardware wallet on transaction service mode. 
Close #354 
# Other changes
- `sign_message` just sign with the first provided owner because Safe Transaction Service is not accepting more than one signature to create the message. https://github.com/safe-global/safe-transaction-service/blob/49c65ec7187a20e06f466ecaeccbc601e8e0f547/safe_transaction_service/safe_messages/serializers.py#L34

