### PR TITLE
Explicitly declare hexbytes dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
     "art>=6",
     "colorama>=0.4",
+    "hexbytes>=0.2.3,<0.4.0",
     "prompt_toolkit>=3",
     "pygments>=2",
     "requests>=2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 art==6.2
 colorama==0.4.6
+hexbytes==0.3.1
 ledgereth==0.9.1
 packaging>=23.1
 prompt_toolkit==3.0.47


### PR DESCRIPTION
We are using `hexbytes` as a dependency in our `argparse_validators` however the dependency is only available transitively.

The following describes how `hexbytes` is provided:

```
hexbytes==0.3.1
├── eth-account==0.11.2 [requires: hexbytes>=0.1.0,<0.4.0]
│   └── web3==6.19.0 [requires: eth-account>=0.8.0,<0.13]
│       └── safe-eth-py==6.0.0b30 [requires: web3>=6.2.0]
│           └── safe-cli==1.2.1 [requires: safe-eth-py==6.0.0b30]
├── eth-rlp==1.0.1 [requires: hexbytes>=0.1.0,<1]
│   └── eth-account==0.11.2 [requires: eth-rlp>=0.3.0]
│       └── web3==6.19.0 [requires: eth-account>=0.8.0,<0.13]
│           └── safe-eth-py==6.0.0b30 [requires: web3>=6.2.0]
│               └── safe-cli==1.2.1 [requires: safe-eth-py==6.0.0b30]
├── trie==3.0.1 [requires: hexbytes>=0.2.3]
│   └── py-evm==0.10.1b1 [requires: trie>=2.0.0]
│       └── safe-eth-py==6.0.0b30 [requires: py-evm>=0.7.0a1]
│           └── safe-cli==1.2.1 [requires: safe-eth-py==6.0.0b30]
└── web3==6.19.0 [requires: hexbytes>=0.1.0,<0.4.0]
    └── safe-eth-py==6.0.0b30 [requires: web3>=6.2.0]
        └── safe-cli==1.2.1 [requires: safe-eth-py==6.0.0b30]
```

We should declare `hexbytes` as a project dependency in case any of the dependencies that include stop using and exporting it.