### PR TITLE
Remove variable shadowing

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -33,7 +33,7 @@ def generate_transfers_erc20(
             account.address, block_identifier="pending"
         )
         # Execute one transfer per each token to send
-        for i in range(num_tokens_to_send):
+        for _ in range(num_tokens_to_send):
             transaction["nonce"] = nonce
             send_tx(w3, transaction, account)
             nonce += 1


### PR DESCRIPTION
Removes the variable shadowing with `i` – this variable is already being used for the outer loop.

While not being used in the inner loop, we should rename it/remove it to avoid potential issues where the variable might be referenced in the future.