### PR TITLE
Remove exception with invalid contract method name in tx-builder

### DIFF
--- a/src/safe_cli/tx_builder/exceptions.py
+++ b/src/safe_cli/tx_builder/exceptions.py
@@ -4,7 +4,3 @@ class SoliditySyntaxError(Exception):
 
 class TxBuilderEncodingError(Exception):
     pass
-
-
-class InvalidContratMethodError(Exception):
-    pass

--- a/tests/test_tx_builder_file_decoder.py
+++ b/tests/test_tx_builder_file_decoder.py
@@ -4,11 +4,7 @@ from eth_abi import encode as encode_abi
 from hexbytes import HexBytes
 from web3 import Web3
 
-from safe_cli.tx_builder.exceptions import (
-    InvalidContratMethodError,
-    SoliditySyntaxError,
-    TxBuilderEncodingError,
-)
+from safe_cli.tx_builder.exceptions import SoliditySyntaxError, TxBuilderEncodingError
 from safe_cli.tx_builder.tx_builder_file_decoder import (
     SafeProposedTx,
     _get_base_field_type,
@@ -191,8 +187,9 @@ class TestTxBuilderFileDecoder(SafeCliTestCaseMixin, unittest.TestCase):
         # Test invalid contrat method
         contract_method = {"name": "receive", "inputs": []}
         contract_fields_values = {}
-        with self.assertRaises(InvalidContratMethodError):
+        self.assertIsNone(
             encode_contract_method_to_hex_data(contract_method, contract_fields_values)
+        )
 
         # Test invalid value
         contract_method = {


### PR DESCRIPTION
Problem detected in QA validation. 

When the method we are trying to encode is not valid, we are throwing an exception. This is an error, following the [front-end tx-builder](https://github.com/safe-global/safe-react-apps/blob/8952156607a0f432555e5d699ec21eaea4f25f67/apps/tx-builder/src/utils.ts#L218) steps here should return a None.