### PR TITLE
Update safe-eth-py package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "prompt_toolkit>=3",
     "pygments>=2",
     "requests>=2",
-    "safe-eth-py==6.0.0b35",
+    "safe-eth-py@git+https://github.com/safe-global/safe-eth-py#egg=update-gnosis-package",
     "tabulate>=0.8",
     "typer==0.12.3",
 ]
@@ -58,6 +58,8 @@ include = ["/src/safe_cli"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["/src/safe_cli"]
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.coverage.run]
 source_pkgs = ["safe_cli", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "prompt_toolkit>=3",
     "pygments>=2",
     "requests>=2",
-    "safe-eth-py@git+https://github.com/safe-global/safe-eth-py#egg=update-gnosis-package",
+    "safe-eth-py==6.0.0b37",
     "tabulate>=0.8",
     "typer==0.12.3",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ packaging>=23.1
 prompt_toolkit==3.0.47
 pygments==2.18.0
 requests==2.32.3
-safe-eth-py==6.0.0b35
+safe-eth-py @ git+https://github.com/safe-global/safe-eth-py@update-gnosis-package
 tabulate==0.9.0
 trezor==0.13.9
 typer==0.12.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ packaging>=23.1
 prompt_toolkit==3.0.47
 pygments==2.18.0
 requests==2.32.3
-safe-eth-py @ git+https://github.com/safe-global/safe-eth-py@update-gnosis-package
+safe-eth-py==6.0.0b37
 tabulate==0.9.0
 trezor==0.13.9
 typer==0.12.3

--- a/src/safe_cli/operators/hw_wallets/hw_wallet_manager.py
+++ b/src/safe_cli/operators/hw_wallets/hw_wallet_manager.py
@@ -5,16 +5,15 @@ from typing import Dict, List, Optional, Set, Tuple
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
 from prompt_toolkit import HTML, print_formatted_text
-from web3.types import TxParams, Wei
-
-from gnosis.eth import TxSpeed
-from gnosis.eth.eip712 import eip712_encode, eip712_encode_hash
-from gnosis.safe import SafeTx
-from gnosis.safe.safe_signature import (
+from safe_eth.eth import TxSpeed
+from safe_eth.eth.eip712 import eip712_encode, eip712_encode_hash
+from safe_eth.safe import SafeTx
+from safe_eth.safe.safe_signature import (
     SafeSignature,
     SafeSignatureEOA,
     SafeSignatureEthSign,
 )
+from web3.types import TxParams, Wei
 
 from .hw_wallet import HwWallet
 

--- a/src/safe_cli/operators/hw_wallets/ledger_wallet.py
+++ b/src/safe_cli/operators/hw_wallets/ledger_wallet.py
@@ -6,9 +6,8 @@ from ledgerblue.Dongle import Dongle
 from ledgereth import create_transaction, sign_message, sign_typed_data_draft
 from ledgereth.accounts import get_account_by_path
 from ledgereth.comms import init_dongle
+from safe_eth.safe.signatures import signature_to_bytes
 from web3.types import TxParams
-
-from gnosis.safe.signatures import signature_to_bytes
 
 from .hw_wallet import HwWallet
 from .ledger_exceptions import raise_ledger_exception_as_hw_wallet_exception

--- a/src/safe_cli/operators/hw_wallets/trezor_wallet.py
+++ b/src/safe_cli/operators/hw_wallets/trezor_wallet.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 import rlp
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
+from safe_eth.safe.signatures import signature_split, signature_to_bytes
 from trezorlib import tools
 from trezorlib.client import TrezorClient, get_default_client
 from trezorlib.ethereum import (
@@ -14,8 +15,6 @@ from trezorlib.ethereum import (
 )
 from trezorlib.ui import ClickUI
 from web3.types import TxParams
-
-from gnosis.safe.signatures import signature_split, signature_to_bytes
 
 from .hw_wallet import HwWallet
 from .trezor_exceptions import raise_trezor_exception_as_hw_wallet_exception

--- a/src/safe_cli/operators/safe_operator.py
+++ b/src/safe_cli/operators/safe_operator.py
@@ -12,30 +12,29 @@ from eth_utils import ValidationError
 from hexbytes import HexBytes
 from packaging import version as semantic_version
 from prompt_toolkit import HTML, print_formatted_text
-from web3 import Web3
-from web3.contract import Contract
-from web3.exceptions import BadFunctionCallOutput
-
-from gnosis.eth import (
+from safe_eth.eth import (
     EthereumClient,
     EthereumNetwork,
     EthereumNetworkNotSupported,
     TxSpeed,
 )
-from gnosis.eth.clients import EtherscanClient, EtherscanClientConfigurationProblem
-from gnosis.eth.constants import NULL_ADDRESS, SENTINEL_ADDRESS
-from gnosis.eth.contracts import (
+from safe_eth.eth.clients import EtherscanClient, EtherscanClientConfigurationProblem
+from safe_eth.eth.constants import NULL_ADDRESS, SENTINEL_ADDRESS
+from safe_eth.eth.contracts import (
     get_erc20_contract,
     get_erc721_contract,
     get_safe_V1_1_1_contract,
     get_sign_message_lib_contract,
 )
-from gnosis.eth.eip712 import eip712_encode
-from gnosis.eth.utils import get_empty_tx_params
-from gnosis.safe import InvalidInternalTx, Safe, SafeOperationEnum, SafeTx
-from gnosis.safe.api import TransactionServiceApi
-from gnosis.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
-from gnosis.safe.safe_deployments import safe_deployments
+from safe_eth.eth.eip712 import eip712_encode
+from safe_eth.eth.utils import get_empty_tx_params
+from safe_eth.safe import InvalidInternalTx, Safe, SafeOperationEnum, SafeTx
+from safe_eth.safe.api import TransactionServiceApi
+from safe_eth.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
+from safe_eth.safe.safe_deployments import safe_deployments
+from web3 import Web3
+from web3.contract import Contract
+from web3.exceptions import BadFunctionCallOutput
 
 from safe_cli.ethereum_hd_wallet import get_account_from_words
 from safe_cli.operators.exceptions import (

--- a/src/safe_cli/operators/safe_tx_service_operator.py
+++ b/src/safe_cli/operators/safe_tx_service_operator.py
@@ -8,18 +8,17 @@ from eth_account.signers.local import LocalAccount
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
 from prompt_toolkit import HTML, print_formatted_text
-from tabulate import tabulate
-
-from gnosis.eth.contracts import get_erc20_contract
-from gnosis.eth.eip712 import eip712_encode_hash
-from gnosis.safe import SafeOperationEnum, SafeTx
-from gnosis.safe.api import SafeAPIException
-from gnosis.safe.api.transaction_service_api.transaction_service_messages import (
+from safe_eth.eth.contracts import get_erc20_contract
+from safe_eth.eth.eip712 import eip712_encode_hash
+from safe_eth.safe import SafeOperationEnum, SafeTx
+from safe_eth.safe.api import SafeAPIException
+from safe_eth.safe.api.transaction_service_api.transaction_service_messages import (
     get_remove_transaction_message,
 )
-from gnosis.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
-from gnosis.safe.safe_signature import SafeSignature
-from gnosis.safe.signatures import signature_to_bytes
+from safe_eth.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
+from safe_eth.safe.safe_signature import SafeSignature
+from safe_eth.safe.signatures import signature_to_bytes
+from tabulate import tabulate
 
 from ..utils import get_input, yes_or_no_question
 from . import SafeServiceNotAvailable

--- a/src/safe_cli/prompt_parser.py
+++ b/src/safe_cli/prompt_parser.py
@@ -3,8 +3,7 @@ import functools
 
 from prompt_toolkit import HTML, print_formatted_text
 from prompt_toolkit.formatted_text import html
-
-from gnosis.safe.api import SafeAPIException
+from safe_eth.safe.api import SafeAPIException
 
 from .argparse_validators import (
     check_ethereum_address,

--- a/src/safe_cli/safe_addresses.py
+++ b/src/safe_cli/safe_addresses.py
@@ -8,8 +8,7 @@ https://github.com/gnosis/safe-deployments/tree/main/src/assets/v1.3.0
 from typing import Sequence
 
 from eth_typing import ChecksumAddress
-
-from gnosis.eth import EthereumClient
+from safe_eth.eth import EthereumClient
 
 
 def _get_valid_contract(

--- a/src/safe_cli/safe_creator.py
+++ b/src/safe_cli/safe_creator.py
@@ -10,11 +10,10 @@ from eth_account.signers.local import LocalAccount
 from eth_typing import URI
 from hexbytes import HexBytes
 from prompt_toolkit import print_formatted_text
-
-from gnosis.eth import EthereumClient, EthereumTxSent
-from gnosis.eth.constants import NULL_ADDRESS
-from gnosis.eth.contracts import get_safe_V1_4_1_contract
-from gnosis.safe import ProxyFactory, Safe
+from safe_eth.eth import EthereumClient, EthereumTxSent
+from safe_eth.eth.constants import NULL_ADDRESS
+from safe_eth.eth.contracts import get_safe_V1_4_1_contract
+from safe_eth.safe import ProxyFactory, Safe
 
 from safe_cli.safe_addresses import (
     get_default_fallback_handler_address,

--- a/src/safe_cli/utils.py
+++ b/src/safe_cli/utils.py
@@ -3,9 +3,8 @@ from typing import List, Optional
 
 from eth_typing import ChecksumAddress
 from prompt_toolkit import HTML, print_formatted_text
-
-from gnosis.eth import EthereumClient
-from gnosis.safe.api import TransactionServiceApi
+from safe_eth.eth import EthereumClient
+from safe_eth.safe.api import TransactionServiceApi
 
 
 def get_erc_20_list(

--- a/tests/safe_cli_test_case_mixin.py
+++ b/tests/safe_cli_test_case_mixin.py
@@ -1,9 +1,8 @@
 from unittest import mock
 
 from eth_account import Account
-
-from gnosis.eth import EthereumClient, EthereumNetwork
-from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.eth import EthereumClient, EthereumNetwork
+from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 
 from safe_cli.operators import SafeOperator, SafeOperatorMode, SafeTxServiceOperator
 

--- a/tests/test_hw_wallet_manager.py
+++ b/tests/test_hw_wallet_manager.py
@@ -6,9 +6,8 @@ from eth_account import Account
 from hexbytes import HexBytes
 from ledgerblue.Dongle import Dongle
 from ledgereth import SignedTransaction
-
-from gnosis.safe import SafeTx
-from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.safe import SafeTx
+from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 
 from safe_cli.operators.hw_wallets.hw_wallet_manager import (
     HwWalletManager,

--- a/tests/test_ledger_wallet.py
+++ b/tests/test_ledger_wallet.py
@@ -13,11 +13,10 @@ from ledgereth.exceptions import (
     LedgerNotFound,
 )
 from ledgereth.objects import LedgerAccount, SignedMessage, SignedTransaction
-
-from gnosis.eth.eip712 import eip712_encode
-from gnosis.safe import SafeTx
-from gnosis.safe.signatures import signature_split
-from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
+from safe_eth.eth.eip712 import eip712_encode
+from safe_eth.safe import SafeTx
+from safe_eth.safe.signatures import signature_split
+from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 
 from safe_cli.operators.exceptions import HardwareWalletException
 from safe_cli.operators.hw_wallets.ledger_wallet import LedgerWallet

--- a/tests/test_safe_addresses.py
+++ b/tests/test_safe_addresses.py
@@ -1,9 +1,8 @@
 import unittest
 
 from eth_account import Account
-
-from gnosis.eth import EthereumClient
-from gnosis.eth.tests.utils import just_test_if_mainnet_node
+from safe_eth.eth import EthereumClient
+from safe_eth.eth.tests.utils import just_test_if_mainnet_node
 
 from safe_cli.safe_addresses import (
     _get_valid_contract,

--- a/tests/test_safe_cli.py
+++ b/tests/test_safe_cli.py
@@ -1,9 +1,8 @@
 import unittest
 
 from eth_account import Account
+from safe_eth.safe import Safe
 from web3 import Web3
-
-from gnosis.safe import Safe
 
 from safe_cli.operators import SafeCliTerminationException
 from safe_cli.operators.safe_operator import SafeOperator

--- a/tests/test_safe_cli_entry_point.py
+++ b/tests/test_safe_cli_entry_point.py
@@ -6,13 +6,12 @@ from unittest.mock import MagicMock
 import pytest
 from eth_account import Account
 from eth_typing import HexStr
+from safe_eth.eth import EthereumClient
+from safe_eth.eth.constants import NULL_ADDRESS
+from safe_eth.safe import Safe
+from safe_eth.safe.api import TransactionServiceApi
+from safe_eth.safe.safe import SafeInfo
 from typer.testing import CliRunner
-
-from gnosis.eth import EthereumClient
-from gnosis.eth.constants import NULL_ADDRESS
-from gnosis.safe import Safe
-from gnosis.safe.api import TransactionServiceApi
-from gnosis.safe.safe import SafeInfo
 
 from safe_cli import VERSION
 from safe_cli.main import app

--- a/tests/test_safe_creator.py
+++ b/tests/test_safe_creator.py
@@ -4,8 +4,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from eth_account import Account
-
-from gnosis.safe import Safe
+from safe_eth.safe import Safe
 
 from safe_cli.safe_creator import main
 

--- a/tests/test_safe_operator.py
+++ b/tests/test_safe_operator.py
@@ -8,13 +8,12 @@ from eth_account import Account
 from eth_typing import ChecksumAddress
 from ledgerblue.Dongle import Dongle
 from ledgereth.objects import LedgerAccount
+from safe_eth.eth import EthereumClient
+from safe_eth.eth.eip712 import eip712_encode
+from safe_eth.safe import Safe
+from safe_eth.safe.multi_send import MultiSend
 from web3 import Web3
 from web3.types import Wei
-
-from gnosis.eth import EthereumClient
-from gnosis.eth.eip712 import eip712_encode
-from gnosis.safe import Safe
-from gnosis.safe.multi_send import MultiSend
 
 from safe_cli.contracts import safe_to_l2_migration
 from safe_cli.operators.exceptions import (
@@ -64,7 +63,7 @@ class TestSafeOperator(SafeCliTestCaseMixin, unittest.TestCase):
             self.assertEqual(len(safe.retrieve_owners()), number_owners)
 
     @mock.patch(
-        "gnosis.safe.Safe.contract", new_callable=mock.PropertyMock, return_value=None
+        "safe_eth.safe.Safe.contract", new_callable=mock.PropertyMock, return_value=None
     )
     def test_load_cli_owner(self, get_contract_mock: MagicMock):
         random_address = Account.create().address

--- a/tests/test_safe_tx_service_operator.py
+++ b/tests/test_safe_tx_service_operator.py
@@ -5,11 +5,10 @@ from unittest.mock import MagicMock
 from eth_account import Account
 from hexbytes import HexBytes
 from ledgereth.objects import LedgerAccount
+from safe_eth.eth import EthereumClient
+from safe_eth.safe import SafeTx
+from safe_eth.safe.api import SafeAPIException, TransactionServiceApi
 from web3 import Web3
-
-from gnosis.eth import EthereumClient
-from gnosis.safe import SafeTx
-from gnosis.safe.api import SafeAPIException, TransactionServiceApi
 
 from safe_cli.operators import SafeOperatorMode, SafeTxServiceOperator
 
@@ -122,7 +121,7 @@ class TestSafeTxServiceOperator(SafeCliTestCaseMixin, unittest.TestCase):
     @mock.patch.object(TransactionServiceApi, "delete_transaction", return_value=None)
     @mock.patch.object(TransactionServiceApi, "get_safe_transaction")
     @mock.patch(
-        "gnosis.safe.api.transaction_service_api.transaction_service_messages.get_totp",
+        "safe_eth.safe.api.transaction_service_api.transaction_service_messages.get_totp",
         return_value=8365,
     )
     def test_remove_transaction(

--- a/tests/test_trezor_wallet.py
+++ b/tests/test_trezor_wallet.py
@@ -5,16 +5,15 @@ from unittest.mock import MagicMock
 
 from eth_account import Account
 from hexbytes import HexBytes
+from safe_eth.eth.eip712 import eip712_encode
+from safe_eth.safe import SafeTx
+from safe_eth.safe.signatures import signature_split, signature_to_bytes
+from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 from trezorlib.client import TrezorClient
 from trezorlib.exceptions import Cancelled, OutdatedFirmwareError, PinException
 from trezorlib.messages import EthereumTypedDataSignature
 from trezorlib.transport import TransportException
 from trezorlib.ui import ClickUI
-
-from gnosis.eth.eip712 import eip712_encode
-from gnosis.safe import SafeTx
-from gnosis.safe.signatures import signature_split, signature_to_bytes
-from gnosis.safe.tests.safe_test_case import SafeTestCaseMixin
 
 from safe_cli.operators.exceptions import HardwareWalletException
 from safe_cli.operators.hw_wallets.trezor_wallet import TrezorWallet

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,5 @@
 from eth_account.signers.local import LocalAccount
-
-from gnosis.eth.tests.utils import deploy_erc20, send_tx
+from safe_eth.eth.tests.utils import deploy_erc20, send_tx
 
 from safe_cli.operators import SafeOperator
 


### PR DESCRIPTION
# Description 
Prepare `safe-cli` to migrate to new package name changed in https://github.com/safe-global/safe-eth-py/pull/1286