### PR TITLE
typo fix ledger_exceptions.py

### DIFF
--- a/src/safe_cli/operators/hw_wallets/ledger_exceptions.py
+++ b/src/safe_cli/operators/hw_wallets/ledger_exceptions.py
@@ -28,7 +28,7 @@ def raise_ledger_exception_as_hw_wallet_exception(function):
             raise HardwareWalletException(e.message)
         except BaseException as e:
             if "Error while writing" in e.args:
-                raise HardwareWalletException("Ledger error writting, restart safe-cli")
+                raise HardwareWalletException("Ledger error writing, restart safe-cli")
             raise e
 
     return wrapper


### PR DESCRIPTION
## Typo Fix in `ledger_exceptions.py`

This pull request fixes a typographical error in the `ledger_exceptions.py` file. The word "writting" was corrected to "writing" to ensure proper spelling in the exception message.

### Changes:
- Corrected the spelling of "writting" to "writing" in the error message raised for the Ledger hardware wallet.

### Checklist:
- [x] Fixed spelling error in the exception message.
- [x] Changes reviewed and tested.
