### PR TITLE
Add zkSync addresses for version 1.4.1 in safe_addresses.py

### DIFF
--- a/src/safe_cli/safe_addresses.py
+++ b/src/safe_cli/safe_addresses.py
@@ -42,6 +42,7 @@ def get_safe_l2_contract_address(ethereum_client: EthereumClient) -> ChecksumAdd
         ethereum_client,
         [
             "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",  # v1.4.1
+            "0x610fcA2e0279Fa1F8C00c8c2F71dF522AD469380",  # v1.4.1 zkSync
             "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",  # v1.3.0
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",  # v1.3.0
             "0x1727c2c531cf966f902E5927b98490fDFb3b2b70",  # v1.3.0 zkSync
@@ -56,6 +57,7 @@ def get_default_fallback_handler_address(
         ethereum_client,
         [
             "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",  # v1.4.1
+            "0x9301E98DD367135f21bdF66f342A249c9D5F9069",  # v1.4.1 zkSync
             "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",  # v1.3.0
             "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804",  # v1.3.0
             "0x2f870a80647BbC554F3a0EBD093f11B4d2a7492A",  # v1.3.0 zkSync
@@ -68,6 +70,7 @@ def get_proxy_factory_address(ethereum_client: EthereumClient) -> ChecksumAddres
         ethereum_client,
         [
             "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",  # v1.4.1
+            "0xc329D02fd8CB2fc13aa919005aF46320794a8629",  # v1.4.1 zkSync
             "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",  # v1.3.0
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",  # v1.3.0
             "0xDAec33641865E4651fB43181C6DB6f7232Ee91c2",  # v1.3.0 zkSync
@@ -80,6 +83,7 @@ def get_last_multisend_address(ethereum_client: EthereumClient) -> ChecksumAddre
         ethereum_client,
         [
             "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",  # v1.4.1
+            "0x309D0B190FeCCa8e1D5D8309a16F7e3CB133E885",  # v1.4.1 zkSync
             "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",  # v1.3.0
             "0x998739BFdAAdde7C933B942a68053933098f9EDa",  # v1.3.0
             "0x0dFcccB95225ffB03c6FBB2559B530C2B7C8A912",  # v1.3.0 zkSync
@@ -94,6 +98,7 @@ def get_last_multisend_call_only_address(
         ethereum_client,
         [
             "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",  # v1.4.1
+            "0x0408EF011960d02349d50286D20531229BCef773",  # v1.4.1 zkSync
             "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",  # v1.3.0
             "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B",  # v1.3.0
             "0xf220D3b4DFb23C4ade8C88E526C1353AbAcbC38F",  # v1.3.0 zkSync
@@ -108,6 +113,7 @@ def get_last_sign_message_lib_address(
         ethereum_client,
         [
             "0xd53cd0aB83D845Ac265BE939c57F53AD838012c9",  # v1.4.1
+            "0xAca1ec0a1A575CDCCF1DC3d5d296202Eb6061888",  # v1.4.1 zkSync
             "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",  # v1.3.0
             "0x98FFBBF51bb33A056B08ddf711f289936AafF717",  # v1.3.0
             "0x357147caf9C0cCa67DfA0CF5369318d8193c8407",  # v1.3.0 zkSync


### PR DESCRIPTION
This PR adds the following Safe v1.4.1 contract addresses for zkSync network:

- Safe Singleton: `0x610fcA2e0279Fa1F8C00c8c2F71dF522AD469380`
- Default Fallback Handler: `0x9301E98DD367135f21bdF66f342A249c9D5F9069`  
- Proxy Factory: `0xc329D02fd8CB2fc13aa919005aF46320794a8629`
- MultiSend: `0x309D0B190FeCCa8e1D5D8309a16F7e3CB133E885`
- MultiSendCallOnly: `0x0408EF011960d02349d50286D20531229BCef773`
- SignMessageLib: `0xAca1ec0a1A575CDCCF1DC3d5d296202Eb6061888`

These addresses enable Safe v1.4.1 functionality on zkSync network.