### PR TITLE
use EtherscanClientV2 not EtherscanClient

### DIFF
--- a/src/safe_cli/operators/safe_operator.py
+++ b/src/safe_cli/operators/safe_operator.py
@@ -18,7 +18,7 @@ from safe_eth.eth import (
     EthereumNetworkNotSupported,
     TxSpeed,
 )
-from safe_eth.eth.clients import EtherscanClient, EtherscanClientConfigurationProblem
+from safe_eth.eth.clients import EtherscanClientV2, EtherscanClientConfigurationProblem
 from safe_eth.eth.constants import NULL_ADDRESS, SENTINEL_ADDRESS
 from safe_eth.eth.contracts import (
     get_erc20_contract,
@@ -141,7 +141,7 @@ class SafeOperator:
     ethereum_client: EthereumClient
     ens: ENS
     network: EthereumNetwork
-    etherscan: Optional[EtherscanClient]
+    etherscan: Optional[EtherscanClientV2]
     safe_tx_service: Optional[TransactionServiceApi]
     safe: Safe
     safe_contract: Contract
@@ -162,7 +162,7 @@ class SafeOperator:
         self.ens = ENS.from_web3(self.ethereum_client.w3)
         self.network: EthereumNetwork = self.ethereum_client.get_network()
         try:
-            self.etherscan = EtherscanClient(self.network)
+            self.etherscan = EtherscanClientV2(self.network)
         except EtherscanClientConfigurationProblem:
             self.etherscan = None
 


### PR DESCRIPTION
safe-cli was broken, safe-operator worked, but safe-cli gave this error:

 ```
 Traceback (most recent call last):
  File "/Users/denis/software-projects/venv/bin/safe-cli", line 5, in <module>
    from safe_cli.main import main
  File "/Users/denis/software-projects/venv/lib/python3.13/site-packages/safe_cli/main.py", line 18, in <module>
    from .operators import SafeOperator
  File "/Users/denis/software-projects/venv/lib/python3.13/site-packages/safe_cli/operators/__init__.py", line 3, in <module>
    from .safe_operator import SafeOperator
  File "/Users/denis/software-projects/venv/lib/python3.13/site-packages/safe_cli/operators/safe_operator.py", line 21, in <module>
    from safe_eth.eth.clients import EtherscanClient, EtherscanClientConfigurationProblem
ImportError: cannot import name 'EtherscanClient' from 'safe_eth.eth.clients' (/Users/denis/software-projects/venv/lib/python3.13/site-packages/safe_eth/eth/clients/__init__.py)
```