### PR TITLE
Fix correctness bugs and clean up dead code across CLI

### DIFF
--- a/src/safe_cli/ethereum_hd_wallet.py
+++ b/src/safe_cli/ethereum_hd_wallet.py
@@ -17,7 +17,9 @@ def get_account_from_words(
     :raises: eth_utils.ValidationError
     """
     Account.enable_unaudited_hdwallet_features()
-    if index:
+    # Derive from the base path by index only when the caller did not
+    # supply a custom hd_path; otherwise honor the provided hd_path
+    if index and hd_path == ETHEREUM_DEFAULT_PATH:
         hd_path = f"{ETHEREUM_BASE_PATH}/{index}"
     return Account.from_mnemonic(words, account_path=hd_path)
 

--- a/src/safe_cli/main.py
+++ b/src/safe_cli/main.py
@@ -17,6 +17,7 @@ from . import VERSION
 from .argparse_validators import check_hex_str
 from .operators import SafeOperator
 from .safe_cli import SafeCli
+from .tx_builder.exceptions import SoliditySyntaxError, TxBuilderEncodingError
 from .tx_builder.tx_builder_file_decoder import convert_to_proposed_transactions
 from .typer_validators import (
     ChecksumAddressParser,
@@ -46,7 +47,7 @@ def _check_interactive_mode(interactive_mode: bool) -> bool:
 
     # --non-interactive arg > env var.
     env_var = os.getenv("SAFE_CLI_INTERACTIVE")
-    if env_var:
+    if env_var is not None:
         return env_var.lower() in ("true", "1", "yes")
 
     return True
@@ -289,11 +290,19 @@ def tx_builder(
     safe_operator = _build_safe_operator_and_load_keys(
         safe_address, node_url, private_key, interactive
     )
-    data = json.loads(file_path.read_text())
-    safe_txs = [
-        safe_operator.prepare_safe_transaction(tx.to, tx.value, tx.data)
-        for tx in convert_to_proposed_transactions(data)
-    ]
+    try:
+        data = json.loads(file_path.read_text())
+        safe_txs = [
+            safe_operator.prepare_safe_transaction(tx.to, tx.value, tx.data)
+            for tx in convert_to_proposed_transactions(data)
+        ]
+    except (
+        json.JSONDecodeError,
+        KeyError,
+        SoliditySyntaxError,
+        TxBuilderEncodingError,
+    ) as e:
+        raise typer.BadParameter(f"Invalid tx-builder file: {e}") from e
 
     if len(safe_txs) == 0:
         raise typer.BadParameter("No transactions found.")
@@ -385,7 +394,7 @@ def _is_safe_cli_default_command(arguments: list[str]) -> bool:
     # Only added if is not a valid command, and it is an address. safe-cli 0xaddress http://url
     if arguments[1] not in [
         get_command_name(key) for key in get_command(app).commands.keys()
-    ] and Web3.is_checksum_address(arguments[1]):
+    ] and Web3.is_address(arguments[1]):
         return True
 
     return False

--- a/src/safe_cli/operators/hw_wallets/ledger_exceptions.py
+++ b/src/safe_cli/operators/hw_wallets/ledger_exceptions.py
@@ -27,7 +27,7 @@ def raise_ledger_exception_as_hw_wallet_exception(function):
         except InvalidDerivationPath as e:
             raise HardwareWalletException(e.message) from e
         except BaseException as e:
-            if "Error while writing" in e.args:
+            if "Error while writing" in str(e):
                 raise HardwareWalletException(
                     "Ledger error writing, restart safe-cli"
                 ) from e

--- a/src/safe_cli/operators/hw_wallets/trezor_wallet.py
+++ b/src/safe_cli/operators/hw_wallets/trezor_wallet.py
@@ -116,7 +116,7 @@ class TrezorWallet(HwWallet):
                 gas_limit=tx_parameters["gas"],
                 to=tx_parameters["to"],
                 value=tx_parameters["value"],
-                data=HexBytes(tx_parameters.get("data")),
+                data=HexBytes(tx_parameters["data"]),
                 chain_id=chain_id,
             )
 

--- a/src/safe_cli/operators/safe_operator.py
+++ b/src/safe_cli/operators/safe_operator.py
@@ -259,7 +259,15 @@ class SafeOperator:
     def load_cli_owners_from_words(self, words: list[str]):
         if len(words) == 1:  # Reading seed from Environment Variable
             words = os.environ.get(words[0], default="").strip().split(" ")
-        parsed_words = " ".join(words)
+        parsed_words = " ".join(words).strip()
+        if not parsed_words:
+            print_formatted_text(
+                HTML(
+                    "<ansired>Cannot load owners from words: empty seed "
+                    "(check the mnemonic or the environment variable)</ansired>"
+                )
+            )
+            return
         try:
             accounts = []
             for index in range(100):  # Try first 100 accounts of seed phrase
@@ -600,7 +608,9 @@ class SafeOperator:
         elif semantic_version.parse(
             self.safe_cli_info.version
         ) < semantic_version.parse("1.1.0"):
-            raise FallbackHandlerNotSupportedException()
+            raise FallbackHandlerNotSupportedException(
+                "Fallback handler is not supported for Safes with version < 1.1.0"
+            )
         elif (
             new_fallback_handler != NULL_ADDRESS
             and not self.ethereum_client.is_contract(new_fallback_handler)
@@ -616,6 +626,7 @@ class SafeOperator:
                 self.safe_cli_info.fallback_handler = new_fallback_handler
                 self.safe_cli_info.version = self.safe.retrieve_version()
                 return True
+            return False
 
     def change_guard(self, guard: str) -> bool:
         if guard == self.safe_cli_info.guard:
@@ -623,7 +634,9 @@ class SafeOperator:
         elif semantic_version.parse(
             self.safe_cli_info.version
         ) < semantic_version.parse("1.3.0"):
-            raise GuardNotSupportedException()
+            raise GuardNotSupportedException(
+                "Guard is not supported for Safes with version < 1.3.0"
+            )
         elif guard != NULL_ADDRESS and not self.ethereum_client.is_contract(guard):
             raise InvalidGuardException(f"{guard} address is not a contract")
         else:
@@ -634,6 +647,7 @@ class SafeOperator:
                 self.safe_cli_info.guard = guard
                 self.safe_cli_info.version = self.safe.retrieve_version()
                 return True
+            return False
 
     def change_module_guard(self, module_guard: str) -> bool:
         if module_guard == self.safe_cli_info.module_guard:
@@ -661,6 +675,7 @@ class SafeOperator:
                 self.safe_cli_info.module_guard = module_guard
                 self.safe_cli_info.version = self.safe.retrieve_version()
                 return True
+            return False
 
     def change_master_copy(self, new_master_copy: str) -> bool:
         if new_master_copy == self.safe_cli_info.master_copy:
@@ -684,6 +699,7 @@ class SafeOperator:
                 self.safe_cli_info.master_copy = new_master_copy
                 self.safe_cli_info.version = self.safe.retrieve_version()
                 return True
+            return False
 
     def update_version(self) -> bool | None:
         """
@@ -739,6 +755,8 @@ class SafeOperator:
                 self.last_default_fallback_handler_address
             )
             self.safe_cli_info.version = self.safe.retrieve_version()
+            return True
+        return False
 
     def update_version_to_l2(
         self, migration_contract_address: ChecksumAddress
@@ -803,11 +821,17 @@ class SafeOperator:
             self.safe_cli_info.master_copy = safe_l2_singleton
             self.safe_cli_info.fallback_handler = fallback_handler
             self.safe_cli_info.version = self.safe.retrieve_version()
+            return True
+        return False
 
     def change_threshold(self, threshold: int):
         if threshold == self.safe_cli_info.threshold:
             print_formatted_text(
                 HTML(f"<ansired>Threshold is already {threshold}</ansired>")
+            )
+        elif threshold < 1:
+            print_formatted_text(
+                HTML("<ansired>Threshold must be at least 1</ansired>")
             )
         elif threshold > len(self.safe_cli_info.owners):
             print_formatted_text(
@@ -1044,7 +1068,7 @@ class SafeOperator:
                             f"deducted={fees}</ansigreen>"
                         )
                     )
-                    self.safe_cli_info.nonce += 1
+                    self.safe_cli_info.nonce = safe_tx.safe_nonce + 1
                     return True
                 else:
                     print_formatted_text(

--- a/src/safe_cli/operators/safe_tx_service_operator.py
+++ b/src/safe_cli/operators/safe_tx_service_operator.py
@@ -77,6 +77,7 @@ class SafeTxServiceOperator(SafeOperator):
             print_formatted_text(
                 HTML("<ansired>At least one owner must be loaded</ansired>")
             )
+            return False
 
         if self.safe_tx_service.post_message(self.address, message, signature):
             print_formatted_text(
@@ -114,6 +115,7 @@ class SafeTxServiceOperator(SafeOperator):
             print_formatted_text(
                 HTML(f"<ansired>Owner with address {sender} was not loaded</ansired>")
             )
+            return False
 
         if isinstance(signer, LocalAccount):
             signature = signer.unsafe_sign_hash(safe_message_hash).signature

--- a/src/safe_cli/prompt_parser.py
+++ b/src/safe_cli/prompt_parser.py
@@ -1,5 +1,6 @@
 import argparse
 import functools
+import shlex
 
 from prompt_toolkit import HTML, print_formatted_text
 from prompt_toolkit.formatted_text import html
@@ -134,7 +135,8 @@ def safe_exception(function):
                 HTML(f"<ansired>HwDevice exception: {e.args[0]}</ansired>")
             )
         except SafeOperatorException as e:
-            print_formatted_text(HTML(f"<ansired>{e.args[0]}</ansired>"))
+            message = e.args[0] if e.args else type(e).__name__
+            print_formatted_text(HTML(f"<ansired>{message}</ansired>"))
 
     return wrapper
 
@@ -146,7 +148,14 @@ class PromptParser:
         self.prompt_parser = build_prompt_parser(safe_operator)
 
     def process_command(self, command: str):
-        args = self.prompt_parser.parse_args(command.split())
+        try:
+            split_command = shlex.split(command)
+        except ValueError as e:
+            print_formatted_text(
+                HTML(f"<ansired>Invalid command syntax: {e}</ansired>")
+            )
+            return
+        args = self.prompt_parser.parse_args(split_command)
         return args.func(args)
 
 

--- a/src/safe_cli/safe_completer.py
+++ b/src/safe_cli/safe_completer.py
@@ -3,8 +3,9 @@ from prompt_toolkit.completion import CompleteEvent, Completer, Completion
 from prompt_toolkit.document import Document
 
 from .safe_completer_constants import (
+    SAFE_ARGUMENT_COLOR,
+    SAFE_EMPTY_ARGUMENT_COLOR,
     meta,
-    safe_color_arguments,
     safe_commands,
     safe_commands_arguments,
 )
@@ -32,8 +33,10 @@ class SafeCompleter(Completer):
                 if command.startswith(word.lower()):
                     if command in safe_commands_arguments:
                         safe_command = safe_commands_arguments[command]
-                        safe_argument_color = safe_color_arguments.get(
-                            safe_command, "default"
+                        safe_argument_color = (
+                            SAFE_ARGUMENT_COLOR
+                            if safe_command
+                            else SAFE_EMPTY_ARGUMENT_COLOR
                         )
                         display = HTML(
                             "<b><ansired> &gt; </ansired>%s</b> <"

--- a/src/safe_cli/safe_completer_constants.py
+++ b/src/safe_cli/safe_completer_constants.py
@@ -14,7 +14,7 @@ safe_commands_arguments = {
     "change_guard": "<address>",
     "change_module_guard": "<address>",
     "change_master_copy": "<address>",
-    "change_threshold": "<address>",
+    "change_threshold": "<integer>",
     "disable_module": "<address>",
     "enable_module": "<address>",
     "execute-tx": "<safe-tx-hash>",
@@ -51,18 +51,6 @@ safe_commands_arguments = {
 }
 
 safe_commands = list(safe_commands_arguments.keys())
-
-safe_color_arguments = {
-    "(read-only)": SAFE_ARGUMENT_COLOR,
-    "<account-private-key>": SAFE_ARGUMENT_COLOR,
-    "<address>": SAFE_ARGUMENT_COLOR,
-    "<hex-str>": SAFE_ARGUMENT_COLOR,
-    "<integer>": SAFE_ARGUMENT_COLOR,
-    "<safe-tx-hash>": SAFE_ARGUMENT_COLOR,
-    "<token-address>": SAFE_ARGUMENT_COLOR,
-    "<token-id>": SAFE_ARGUMENT_COLOR,
-    "<value-wei>": SAFE_ARGUMENT_COLOR,
-}
 
 meta = {
     "approve_hash": HTML(
@@ -104,10 +92,6 @@ meta = {
     ),
     "get_delegates": HTML(
         "Command <b>get_delegates</b> will return information about the current delegates."
-    ),
-    "change_owner": HTML(
-        "Command <b>change_owner</b> will change an old account <u>&lt;address&gt;</u> for the new "
-        "check-summed <u>&lt;address&gt;</u> account."
     ),
     "add_owner": HTML(
         "Command <b>add_owner</b> will add a check-summed <u>&lt;address&gt;</u> owner account."

--- a/src/safe_cli/safe_lexer.py
+++ b/src/safe_cli/safe_lexer.py
@@ -8,7 +8,7 @@ class SafeLexer(BashLexer):
     name = "SafeLexer"
     aliases = ["safe_lexer"]
 
-    ADDRESS = r"^0x[aA-zZ,0-9]{40}$|^0x[aA-zZ,0-9]{62}$"
+    ADDRESS = r"^0x[a-fA-F0-9]{40}$|^0x[a-fA-F0-9]{64}$"
     EXTRA_KEYWORDS = {
         "refresh",
         "get_nonce",

--- a/src/safe_cli/tx_builder/tx_builder_file_decoder.py
+++ b/src/safe_cli/tx_builder/tx_builder_file_decoder.py
@@ -21,7 +21,10 @@ def _parse_types_to_encoding_types(contract_fields: list[dict[str, Any]]) -> lis
             component_types = ",".join(
                 component["type"] for component in field["components"]
             )
-            types.append(f"({component_types})")
+            # Preserve any array suffix (e.g. tuple[], tuple[2]) so the
+            # function selector and ABI encoding target the right signature
+            array_suffix = field["type"].removeprefix("tuple")
+            types.append(f"({component_types}){array_suffix}")
         else:
             types.append(field["type"])
 
@@ -42,14 +45,16 @@ def encode_contract_method_to_hex_data(
     if not is_valid_contract_method:
         return None
 
+    contract_fields_values = contract_fields_values or {}
     try:
         encoding_types = _parse_types_to_encoding_types(contract_fields)
-        values = [
-            parse_input_value(
-                field["type"], contract_fields_values.get(field["name"], "")
+        values = []
+        for field in contract_fields:
+            if field["name"] not in contract_fields_values:
+                raise SoliditySyntaxError(f"Missing value for input '{field['name']}'")
+            values.append(
+                parse_input_value(field["type"], contract_fields_values[field["name"]])
             )
-            for field in contract_fields
-        ]
 
         function_signature = f"{contract_method_name}({','.join(encoding_types)})"
         function_selector = Web3.keccak(text=function_signature)[:4]
@@ -81,9 +86,7 @@ def parse_int_value(value: str) -> int:
     if trimmed_value == "":
         raise SoliditySyntaxError("Invalid empty strings for integers")
     try:
-        if not trimmed_value.isdigit() and bool(
-            re.fullmatch(r"0[xX][0-9a-fA-F]+|[0-9a-fA-F]+$", trimmed_value)
-        ):
+        if re.fullmatch(r"0[xX][0-9a-fA-F]+", trimmed_value):
             return int(trimmed_value, 16)
 
         return int(trimmed_value)
@@ -176,18 +179,26 @@ def is_multi_dimensional_array_field_type(field_type: str) -> bool:
     return field_type.count("[") > 1
 
 
+def is_any_array_field_type(field_type: str) -> bool:
+    return is_array_field_type(field_type) or is_multi_dimensional_array_field_type(
+        field_type
+    )
+
+
 def parse_input_value(field_type: str, value: str) -> Any:
     trimmed_value = value.strip() if isinstance(value, str) else value
 
     if is_tuple_field_type(field_type):
-        return tuple(json.loads(trimmed_value))
+        parsed = json.loads(trimmed_value)
+        if is_any_array_field_type(field_type):
+            # Array of tuples (e.g. tuple[]): a list of tuples, not one tuple
+            return [tuple(item) for item in parsed]
+        return tuple(parsed)
 
     if is_array_of_strings_field_type(field_type):
         return json.loads(trimmed_value)
 
-    if is_array_field_type(field_type) or is_multi_dimensional_array_field_type(
-        field_type
-    ):
+    if is_any_array_field_type(field_type):
         return parse_array_of_values(trimmed_value, field_type)
 
     if is_boolean_field_type(field_type):
@@ -228,11 +239,14 @@ def convert_to_proposed_transactions(
                 to_0x_hex_str(encoded_data) if encoded_data is not None else "0x"
             )
 
+        raw_value = transaction.get("value")
+        value = parse_int_value(str(raw_value)) if raw_value not in (None, "") else 0
+
         proposed_transactions.append(
             SafeProposedTx(
                 id=index,
                 to=transaction.get("to"),
-                value=transaction.get("value"),
+                value=value,
                 data=data_value,
             )
         )


### PR DESCRIPTION
## What

Fixes a batch of correctness bugs and removes dead code found during a full-codebase review. No new features, no behavior changes beyond fixing the bugs below.

## Correctness fixes

**tx-builder file decoder** (`tx_builder_file_decoder.py`)
- Preserve the array suffix for tuple-array types (`tuple[]`, `tuple[N]`). Before, the `[]` was dropped, so both the 4-byte selector and the ABI encoding targeted the wrong (non-array) signature — a batch file calling a method with an array-of-structs argument silently built the wrong calldata.
- `parse_int_value` now requires the `0x` prefix for hex. Before, a bare string like `"abc"` / `"deadbeef"` was silently parsed base-16, producing a wrong amount.
- Missing/`null` `contractInputsValues` no longer crashes with an opaque error; a missing per-field value now raises a clear `Missing value for input 'X'`.
- `value` is coerced to `int` (missing/empty defaults to `0`) instead of passing a string/`None` downstream.

**tx-service operator** (`safe_tx_service_operator.py`)
- `confirm_message` and `sign_message` now `return False` after the "owner not loaded" / "no owner loaded" guards, instead of falling through to a `None`-deref crash or posting an empty signature.

**safe operator** (`safe_operator.py`)
- No-arg `SafeOperatorException` subclasses no longer crash the generic handler (`e.args[0]` IndexError); `GuardNotSupportedException` / `FallbackHandlerNotSupportedException` now carry messages.
- `change_*` / `update_version*` always return a `bool` (added the missing failure/success returns).
- `change_threshold` rejects `threshold < 1` locally.
- Cached nonce is set to `safe_tx.safe_nonce + 1` instead of a blind `+= 1`, so the displayed nonce is correct when a custom `--safe-nonce` is used.
- `load_cli_owners_from_words` reports an explicit empty-seed error for an unset/empty env var.

**main / prompt parser**
- `SAFE_CLI_INTERACTIVE=""` is respected instead of silently ignored.
- Default-command routing uses `Web3.is_address`, so a lowercase (non-checksummed) Safe address starts attended mode instead of erroring with "No such command".
- `process_command` uses `shlex.split`, so quoted/multi-word args (e.g. delegate labels with spaces) parse correctly.

**hardware wallet / hd wallet**
- Ledger exception wrapper matches the message with `in str(e)` instead of `in e.args`, so the USB-write recovery hint actually fires.
- `get_account_from_words` no longer overrides a caller-supplied `hd_path` when `index != 0`.
- Trezor legacy-tx `data` access made consistent with the other branches.

## Cleanup

- `safe_lexer`: fixed the address/tx-hash regex (`{62}` → `{64}`, malformed `[aA-zZ,0-9]` → `[a-fA-F0-9]`).
- `safe_completer` / `safe_completer_constants`: argument coloring now works for multi-arg commands; removed the dead `safe_color_arguments` dict, the dead `change_owner` meta entry, and fixed the `change_threshold` hint (`<address>` → `<integer>`).

## Testing

- `ruff check` and `ruff format` clean.
- Full test suite: 83 passed, 1 skipped (ran against local ganache).

## Notes / deliberately out of scope

- Did not change `LedgerWallet.get_address` to pass `self.dongle` — it alters runtime behavior and breaks an existing test that encodes the old contract; real-world impact is low.
- Did not change the `--interactive` vs `SAFE_CLI_INTERACTIVE=0` precedence — current behavior matches the documented "only `--non-interactive` overrides" design.
- Left the `@cache` on `get_trezor_client` (documented as intentional) and the `argparse`/`typer` validator duplication (larger refactor) for follow-ups.